### PR TITLE
Python3 compatibility fixes

### DIFF
--- a/tests/test_webpack_manifest.py
+++ b/tests/test_webpack_manifest.py
@@ -58,7 +58,7 @@ class TestBundles(unittest.TestCase):
             self.assertFalse('should not reach this')
         except webpack_manifest.WebpackError as e:
             self.assertEqual(
-                e.message,
+                e.args[0],
                 'Webpack errors: \n\nerror 1\n\nerror 2',
             )
 
@@ -71,7 +71,7 @@ class TestBundles(unittest.TestCase):
             self.assertFalse('should not reach this')
         except webpack_manifest.WebpackError as e:
             self.assertEqual(
-                e.message,
+                e.args[0],
                 'Webpack errors: \n\nerror 1\n\nerror 2',
             )
 
@@ -87,7 +87,7 @@ class TestBundles(unittest.TestCase):
             self.assertFalse('should not reach this')
         except webpack_manifest.WebpackManifestBuildingStatusTimeout as e:
             self.assertEqual(
-                e.message,
+                e.args[0],
                 'Timed out reading the webpack manifest at "{}"'.format(path),
             )
 
@@ -101,6 +101,6 @@ class TestBundles(unittest.TestCase):
             self.assertFalse('should not reach this')
         except webpack_manifest.WebpackManifestStatusError as e:
             self.assertEqual(
-                e.message,
+                e.args[0],
                 'Unknown webpack manifest status: "unknown status"',
             )

--- a/webpack_manifest/webpack_manifest.py
+++ b/webpack_manifest/webpack_manifest.py
@@ -186,7 +186,7 @@ def read(path, read_retry):
         raise WebpackManifestFileError('Path "{}" is not an absolute path to a file'.format(path))
 
     with open(path, 'r') as manifest_file:
-        content = manifest_file.read().encode('utf-8')
+        content = manifest_file.read()
 
     # In certain conditions, the file's contents evaluate to an empty string, so
     # we provide a hook to perform a single retry after a delay.


### PR DESCRIPTION
The latest version didn't work in Python 3.5 due to JSON loading errors:

```
ERROR: test_status_handled (tests.test_webpack_manifest.TestBundles)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/semenov/work/github/patches/python-webpack-manifest/tests/test_webpack_manifest.py", line 69, in test_status_handled
    static_url='/static',
  File "/Users/semenov/work/github/patches/python-webpack-manifest/webpack_manifest/webpack_manifest.py", line 108, in load
    manifest = build(path, static_url, debug, timeout, read_retry)
  File "/Users/semenov/work/github/patches/python-webpack-manifest/webpack_manifest/webpack_manifest.py", line 119, in build
    data = read(path, read_retry)
  File "/Users/semenov/work/github/patches/python-webpack-manifest/webpack_manifest/webpack_manifest.py", line 198, in read
    return json.loads(content)
  File "/Users/semenov/.pyenv/versions/3.5.2/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```

Also, all the exception tests were broken in Python3 since Exception.message attribute was removed.

The PR fixes both problems. Tested in 2.7.12 and 3.5.2.